### PR TITLE
Disable zoom on text fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>ShipBuilder</title>
   </head>
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,29 @@ body {
   overflow: hidden;
 }
 
+/* Prevent mobile zoom on input fields */
+@media (max-width: 768px) {
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="number"],
+  input[type="tel"],
+  input[type="url"],
+  input[type="search"],
+  input[type="date"],
+  input[type="time"],
+  input[type="datetime-local"],
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+  
+  /* Ensure our UI components also respect the 16px minimum */
+  [data-slot="input"],
+  [data-slot="textarea"] {
+    font-size: 16px !important;
+  }
+}
 
 /* Custom scrollbar styles for dark theme */
 ::-webkit-scrollbar {
@@ -500,8 +523,6 @@ input, select, textarea, [role="combobox"] {
   --sidebar-border: oklch(0.291 0.036 45);
   --sidebar-ring: oklch(0.748 0.148 25);
 }
-
-
 
 .midnight {
   --background: oklch(0.08 0.05 250);


### PR DESCRIPTION
Prevent mobile browsers from automatically zooming on text input fields.

Mobile browsers, particularly iOS Safari, automatically zoom into input fields when their font size is less than 16px. This PR addresses this by ensuring a minimum font size of 16px for inputs on mobile and by restricting user-scalable zoom via the viewport meta tag.