### PR TITLE
Fix: Standardize project deletion dialogs with click-to-copy functionality

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -39,7 +39,8 @@ import {
   LogOut,
   CheckSquare,
   Rocket,
-  Trash2
+  Trash2,
+  Copy
 } from 'lucide-react'
 import { useProjects } from '@/context/ProjectContext'
 import { useAuth } from '@/context/AuthContext'
@@ -320,16 +321,25 @@ export function AppSidebar({ currentView, onViewChange, onProjectSelect, onMVPBu
                 This action cannot be undone. This will permanently delete the project <strong>"{projectToDelete?.name}"</strong> and all its tasks.
               </p>
               <p className="text-sm font-medium">
-                To confirm, type the project name exactly: <code 
-                  className="bg-muted px-1 rounded text-xs cursor-pointer hover:bg-muted/80 transition-colors"
+                To confirm, type the project name exactly:
+              </p>
+              <div className="flex items-center gap-2">
+                <code className="bg-muted px-2 py-1 rounded text-sm">{projectToDelete?.name}</code>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-6 px-2"
                   onClick={() => {
                     if (projectToDelete?.name) {
                       navigator.clipboard.writeText(projectToDelete.name)
                     }
                   }}
                   title="Click to copy project name"
-                >{projectToDelete?.name}</code>
-              </p>
+                >
+                  <Copy className="h-3 w-3" />
+                </Button>
+              </div>
             </div>
             <Input
               value={confirmationText}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -25,13 +25,10 @@ import { UserProfile } from '@/components/UserProfile'
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { 
   Circle, 
   CircleCheckBig, 
@@ -313,38 +310,53 @@ export function AppSidebar({ currentView, onViewChange, onProjectSelect, onMVPBu
       
       {/* Delete Confirmation Dialog */}
       <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <DialogContent>
+        <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Delete Project</DialogTitle>
-            <DialogDescription>
-              This action cannot be undone. This will permanently delete the project "{projectToDelete?.name}" and all of its tasks.
-            </DialogDescription>
           </DialogHeader>
-          <div className="py-4">
-            <Label htmlFor="confirmation" className="text-sm font-medium">
-              Type the project name "{projectToDelete?.name}" to confirm deletion:
-            </Label>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                This action cannot be undone. This will permanently delete the project <strong>"{projectToDelete?.name}"</strong> and all its tasks.
+              </p>
+              <p className="text-sm font-medium">
+                To confirm, type the project name exactly: <code 
+                  className="bg-muted px-1 rounded text-xs cursor-pointer hover:bg-muted/80 transition-colors"
+                  onClick={() => {
+                    if (projectToDelete?.name) {
+                      navigator.clipboard.writeText(projectToDelete.name)
+                    }
+                  }}
+                  title="Click to copy project name"
+                >{projectToDelete?.name}</code>
+              </p>
+            </div>
             <Input
-              id="confirmation"
               value={confirmationText}
               onChange={(e) => setConfirmationText(e.target.value)}
-              placeholder={projectToDelete?.name}
-              className="mt-2"
+              placeholder="Type project name to confirm..."
+              autoFocus
               disabled={isDeleting}
             />
+            <div className="flex justify-end gap-2">
+              <Button 
+                type="button" 
+                variant="outline" 
+                onClick={cancelDelete}
+                disabled={isDeleting}
+              >
+                Cancel
+              </Button>
+              <Button 
+                type="button" 
+                variant="destructive" 
+                onClick={confirmDelete}
+                disabled={isDeleting || confirmationText !== projectToDelete?.name}
+              >
+                {isDeleting ? 'Deleting...' : 'Delete Project'}
+              </Button>
+            </div>
           </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={cancelDelete} disabled={isDeleting}>
-              Cancel
-            </Button>
-            <Button 
-              variant="destructive" 
-              onClick={confirmDelete}
-              disabled={isDeleting || confirmationText !== projectToDelete?.name}
-            >
-              {isDeleting ? 'Deleting...' : 'Delete Project'}
-            </Button>
-          </DialogFooter>
         </DialogContent>
       </Dialog>
     </Sidebar>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -341,8 +341,8 @@ export function AppSidebar({ currentView, onViewChange, onProjectSelect, onMVPBu
               <p className="text-sm font-medium">
                 To confirm, type the project name exactly:
               </p>
-              <div className="flex items-center gap-1 px-2 py-1 bg-muted/30 rounded border font-mono cursor-pointer hover:bg-muted/50 transition-colors" onClick={handleCopyProjectName} title="Click to copy project name">
-                <span className="text-sm text-foreground select-all flex-1">
+              <div className="inline-flex items-center gap-1 px-2 py-1 bg-muted/30 rounded border font-mono cursor-pointer hover:bg-muted/50 transition-colors" onClick={handleCopyProjectName} title="Click to copy project name">
+                <span className="text-sm text-foreground select-all">
                   {projectToDelete?.name}
                 </span>
                 <Button

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -329,7 +329,7 @@ export function AppSidebar({ currentView, onViewChange, onProjectSelect, onMVPBu
                   type="button"
                   variant="outline"
                   size="sm"
-                  className="h-6 px-2"
+                  className="h-6 px-2 hover:bg-primary hover:text-primary-foreground hover:border-primary transition-all duration-200 active:scale-95 active:bg-primary/90"
                   onClick={() => {
                     if (projectToDelete?.name) {
                       navigator.clipboard.writeText(projectToDelete.name)

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -40,7 +40,8 @@ import {
   CheckSquare,
   Rocket,
   Trash2,
-  Copy
+  Copy,
+  Check
 } from 'lucide-react'
 import { useProjects } from '@/context/ProjectContext'
 import { useAuth } from '@/context/AuthContext'
@@ -95,6 +96,7 @@ export function AppSidebar({ currentView, onViewChange, onProjectSelect, onMVPBu
   const [projectToDelete, setProjectToDelete] = useState<{ id: string; name: string } | null>(null)
   const [confirmationText, setConfirmationText] = useState('')
   const [isDeleting, setIsDeleting] = useState(false)
+  const [projectNameCopied, setProjectNameCopied] = useState(false)
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
@@ -108,6 +110,22 @@ export function AppSidebar({ currentView, onViewChange, onProjectSelect, onMVPBu
     setProjectToDelete(project)
     setDeleteDialogOpen(true)
     setConfirmationText('')
+    setProjectNameCopied(false)
+  }
+
+  const handleCopyProjectName = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    
+    if (projectToDelete?.name) {
+      try {
+        await navigator.clipboard.writeText(projectToDelete.name)
+        setProjectNameCopied(true)
+        setTimeout(() => setProjectNameCopied(false), 2000)
+      } catch (error) {
+        console.error('Failed to copy project name:', error)
+      }
+    }
   }
 
   const confirmDelete = async () => {
@@ -323,21 +341,22 @@ export function AppSidebar({ currentView, onViewChange, onProjectSelect, onMVPBu
               <p className="text-sm font-medium">
                 To confirm, type the project name exactly:
               </p>
-              <div className="flex items-center gap-2">
-                <code className="bg-muted px-2 py-1 rounded text-sm">{projectToDelete?.name}</code>
+              <div className="flex items-center gap-1 px-2 py-1 bg-muted/30 rounded border font-mono cursor-pointer hover:bg-muted/50 transition-colors" onClick={handleCopyProjectName} title="Click to copy project name">
+                <span className="text-sm text-foreground select-all flex-1">
+                  {projectToDelete?.name}
+                </span>
                 <Button
-                  type="button"
-                  variant="outline"
+                  variant="ghost"
                   size="sm"
-                  className="h-6 px-2 hover:bg-primary hover:text-primary-foreground hover:border-primary transition-all duration-200 active:scale-95 active:bg-primary/90"
-                  onClick={() => {
-                    if (projectToDelete?.name) {
-                      navigator.clipboard.writeText(projectToDelete.name)
-                    }
-                  }}
-                  title="Click to copy project name"
+                  className="h-6 w-6 p-0 hover:bg-muted-foreground/10 transition-colors"
+                  onClick={handleCopyProjectName}
+                  title="Copy project name"
                 >
-                  <Copy className="h-3 w-3" />
+                  {projectNameCopied ? (
+                    <Check className="h-3 w-3 text-green-600" />
+                  ) : (
+                    <Copy className="h-3 w-3 text-muted-foreground" />
+                  )}
                 </Button>
               </div>
             </div>

--- a/src/components/project-view.tsx
+++ b/src/components/project-view.tsx
@@ -28,7 +28,8 @@ import {
   Circle, 
   Trash2,
   Settings,
-  Edit
+  Edit,
+  Copy
 } from 'lucide-react'
 import { useProjects } from '@/context/ProjectContext'
 import { TaskStatus, ProjectStatus } from '@/types/types'
@@ -440,16 +441,25 @@ export function ProjectView({ view, onProjectSelect, newProjectDialogOpen, onNew
                 This action cannot be undone. This will permanently delete the project <strong>"{projectToManage?.name}"</strong> and all its tasks.
               </p>
               <p className="text-sm font-medium">
-                To confirm, type the project name exactly: <code 
-                  className="bg-muted px-1 rounded text-xs cursor-pointer hover:bg-muted/80 transition-colors"
+                To confirm, type the project name exactly:
+              </p>
+              <div className="flex items-center gap-2">
+                <code className="bg-muted px-2 py-1 rounded text-sm">{projectToManage?.name}</code>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-6 px-2"
                   onClick={() => {
                     if (projectToManage?.name) {
                       navigator.clipboard.writeText(projectToManage.name)
                     }
                   }}
                   title="Click to copy project name"
-                >{projectToManage?.name}</code>
-              </p>
+                >
+                  <Copy className="h-3 w-3" />
+                </Button>
+              </div>
             </div>
             <Input
               value={deleteConfirmText}

--- a/src/components/project-view.tsx
+++ b/src/components/project-view.tsx
@@ -461,8 +461,8 @@ export function ProjectView({ view, onProjectSelect, newProjectDialogOpen, onNew
               <p className="text-sm font-medium">
                 To confirm, type the project name exactly:
               </p>
-              <div className="flex items-center gap-1 px-2 py-1 bg-muted/30 rounded border font-mono cursor-pointer hover:bg-muted/50 transition-colors" onClick={handleCopyProjectName} title="Click to copy project name">
-                <span className="text-sm text-foreground select-all flex-1">
+              <div className="inline-flex items-center gap-1 px-2 py-1 bg-muted/30 rounded border font-mono cursor-pointer hover:bg-muted/50 transition-colors" onClick={handleCopyProjectName} title="Click to copy project name">
+                <span className="text-sm text-foreground select-all">
                   {projectToManage?.name}
                 </span>
                 <Button

--- a/src/components/project-view.tsx
+++ b/src/components/project-view.tsx
@@ -449,7 +449,7 @@ export function ProjectView({ view, onProjectSelect, newProjectDialogOpen, onNew
                   type="button"
                   variant="outline"
                   size="sm"
-                  className="h-6 px-2"
+                  className="h-6 px-2 hover:bg-primary hover:text-primary-foreground hover:border-primary transition-all duration-200 active:scale-95 active:bg-primary/90"
                   onClick={() => {
                     if (projectToManage?.name) {
                       navigator.clipboard.writeText(projectToManage.name)

--- a/src/components/project-view.tsx
+++ b/src/components/project-view.tsx
@@ -440,7 +440,15 @@ export function ProjectView({ view, onProjectSelect, newProjectDialogOpen, onNew
                 This action cannot be undone. This will permanently delete the project <strong>"{projectToManage?.name}"</strong> and all its tasks.
               </p>
               <p className="text-sm font-medium">
-                To confirm, type the project name exactly: <code className="bg-muted px-1 rounded text-xs">{projectToManage?.name}</code>
+                To confirm, type the project name exactly: <code 
+                  className="bg-muted px-1 rounded text-xs cursor-pointer hover:bg-muted/80 transition-colors"
+                  onClick={() => {
+                    if (projectToManage?.name) {
+                      navigator.clipboard.writeText(projectToManage.name)
+                    }
+                  }}
+                  title="Click to copy project name"
+                >{projectToManage?.name}</code>
               </p>
             </div>
             <Input

--- a/src/components/project-view.tsx
+++ b/src/components/project-view.tsx
@@ -29,7 +29,8 @@ import {
   Trash2,
   Settings,
   Edit,
-  Copy
+  Copy,
+  Check
 } from 'lucide-react'
 import { useProjects } from '@/context/ProjectContext'
 import { TaskStatus, ProjectStatus } from '@/types/types'
@@ -82,6 +83,7 @@ export function ProjectView({ view, onProjectSelect, newProjectDialogOpen, onNew
   const [deleteConfirmText, setDeleteConfirmText] = useState('')
   const [editingName, setEditingName] = useState('')
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null)
+  const [projectNameCopied, setProjectNameCopied] = useState(false)
   const [newProject, setNewProject] = useState({
     name: '',
     description: '',
@@ -132,6 +134,7 @@ export function ProjectView({ view, onProjectSelect, newProjectDialogOpen, onNew
     if (projectToManage) {
       setDeleteConfirmOpen(true)
       setDeleteConfirmText('')
+      setProjectNameCopied(false)
     }
   }
 
@@ -158,6 +161,21 @@ export function ProjectView({ view, onProjectSelect, newProjectDialogOpen, onNew
 
   const handleStatusChange = async (projectId: string, newStatus: ProjectStatus) => {
     await updateProject(projectId, { status: newStatus })
+  }
+
+  const handleCopyProjectName = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    
+    if (projectToManage?.name) {
+      try {
+        await navigator.clipboard.writeText(projectToManage.name)
+        setProjectNameCopied(true)
+        setTimeout(() => setProjectNameCopied(false), 2000)
+      } catch (error) {
+        console.error('Failed to copy project name:', error)
+      }
+    }
   }
 
   const filteredProjects = projects.filter(project => {
@@ -443,21 +461,22 @@ export function ProjectView({ view, onProjectSelect, newProjectDialogOpen, onNew
               <p className="text-sm font-medium">
                 To confirm, type the project name exactly:
               </p>
-              <div className="flex items-center gap-2">
-                <code className="bg-muted px-2 py-1 rounded text-sm">{projectToManage?.name}</code>
+              <div className="flex items-center gap-1 px-2 py-1 bg-muted/30 rounded border font-mono cursor-pointer hover:bg-muted/50 transition-colors" onClick={handleCopyProjectName} title="Click to copy project name">
+                <span className="text-sm text-foreground select-all flex-1">
+                  {projectToManage?.name}
+                </span>
                 <Button
-                  type="button"
-                  variant="outline"
+                  variant="ghost"
                   size="sm"
-                  className="h-6 px-2 hover:bg-primary hover:text-primary-foreground hover:border-primary transition-all duration-200 active:scale-95 active:bg-primary/90"
-                  onClick={() => {
-                    if (projectToManage?.name) {
-                      navigator.clipboard.writeText(projectToManage.name)
-                    }
-                  }}
-                  title="Click to copy project name"
+                  className="h-6 w-6 p-0 hover:bg-muted-foreground/10 transition-colors"
+                  onClick={handleCopyProjectName}
+                  title="Copy project name"
                 >
-                  <Copy className="h-3 w-3" />
+                  {projectNameCopied ? (
+                    <Check className="h-3 w-3 text-green-600" />
+                  ) : (
+                    <Copy className="h-3 w-3 text-muted-foreground" />
+                  )}
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Fixed inconsistent styling between project deletion dialogs in sidebar and project view
- Added click-to-copy functionality for project names in confirmation dialogs
- Improved visual consistency and user experience

## Changes Made
- **Unified dialog styling**: Both deletion dialogs now use consistent spacing, layout, and visual hierarchy
- **Click-to-copy functionality**: Users can now click on the project name in the confirmation text to copy it to clipboard
- **Enhanced UX**: Added hover states, tooltips, and proper visual feedback
- **Code cleanup**: Removed unused imports and improved code organization

## Testing
- Both deletion dialogs now have identical styling and behavior
- Click-to-copy functionality works for project names in both dialogs
- Hover states and tooltips provide clear user feedback
- All linting errors for modified files have been resolved

🤖 Generated with [Claude Code](https://claude.ai/code)