### PR TITLE
chore: Add temp bug predictor workaround

### DIFF
--- a/.github/workflows/temp-overwatch.yml
+++ b/.github/workflows/temp-overwatch.yml
@@ -1,0 +1,32 @@
+name: Bug Prediction (Overwatch)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  upload-overwatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Overwatch CLI
+        run: |
+          curl -o overwatch-cli https://overwatch.codecov.io/linux/cli
+          chmod +x overwatch-cli
+      # Using --upload-empty-on-error flag to force this step through.
+      # This workflow is a temporary workaround until this alpha feature 
+      # is merged into AI PR review
+      - name: Run Overwatch CLI
+        run: |
+          ./overwatch-cli \
+            --auth-token ${{ secrets.OVERWATCH_SENTRY_AUTH_TOKEN }} \
+            --organization-slug codyde \
+            --upload-empty-on-error \
+            typescript --package-manager pnpm --eslint-pattern src

--- a/.github/workflows/temp-overwatch.yml
+++ b/.github/workflows/temp-overwatch.yml
@@ -27,6 +27,6 @@ jobs:
         run: |
           ./overwatch-cli \
             --auth-token ${{ secrets.OVERWATCH_SENTRY_AUTH_TOKEN }} \
-            --organization-slug codyde \
+            --organization-slug buildwithcode \
             --upload-empty-on-error \
             typescript --package-manager pnpm --eslint-pattern src

--- a/README.md
+++ b/README.md
@@ -346,3 +346,5 @@ ShipBuilder now supports multiple AI providers with intelligent model selection.
 - **For OpenAI**: Set `OPENAI_API_KEY` in your `.env` file
 - You can configure both to allow users to switch between providers
 - Only providers with valid API keys will be available in settings
+
+this is a test


### PR DESCRIPTION
This is a temporary workaround to get this project registered. We don't need to merge this PR as long as the CI runs once to completion.